### PR TITLE
Stabilize jaegerremote sampler test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 - Validate `encoding` configuration for OTLP HTTP exporters in `go.opentelemetry.io/contrib/otelconf`. (#8772)
-- Stabilize gRPC instrumentation tests in `go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc` by ensuring all metric data points are collected before assertion.
+- Stabilize `TestRemotelyControlledSampler_ImmediatelyUpdateOnStartup` in `go.opentelemetry.io/contrib/samplers/jaegerremote` by using `assert.Eventually` instead of `time.Sleep`.
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 - Validate `encoding` configuration for OTLP HTTP exporters in `go.opentelemetry.io/contrib/otelconf`. (#8772)
+- Stabilize `TestRemotelyControlledSampler_ImmediatelyUpdateOnStartup` in `go.opentelemetry.io/contrib/samplers/jaegerremote` by using `assert.Eventually` instead of `time.Sleep`.
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 - Validate `encoding` configuration for OTLP HTTP exporters in `go.opentelemetry.io/contrib/otelconf`. (#8772)
-- Stabilize `TestRemotelyControlledSampler_ImmediatelyUpdateOnStartup` in `go.opentelemetry.io/contrib/samplers/jaegerremote` by using `assert.Eventually` instead of `time.Sleep`.
+- Stabilize gRPC instrumentation tests in `go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc` by ensuring all metric data points are collected before assertion.
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/instrumentation/google.golang.org/grpc/otelgrpc/grpc_stats_handler_test.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/grpc_stats_handler_test.go
@@ -262,36 +262,10 @@ func checkServerSpans(t *testing.T, sr *tracetest.SpanRecorder, addr string) {
 }
 
 func checkClientMetrics(t *testing.T, reader metric.Reader, addr, stabilityOptIn string) {
-	var rm metricdata.ResourceMetrics
-	require.Eventually(t, func() bool {
-		rm = metricdata.ResourceMetrics{}
-		if err := reader.Collect(t.Context(), &rm); err != nil {
-			return false
-		}
-		if len(rm.ScopeMetrics) == 0 || len(rm.ScopeMetrics[0].Metrics) == 0 {
-			return false
-		}
-		isOld := stabilityOptIn == "rpc/old" || stabilityOptIn == "rpc/dup"
-		isNew := stabilityOptIn == "" || stabilityOptIn == "rpc/dup"
-
-		var expectedCount int
-		if isOld {
-			expectedCount++
-		}
-		if isNew {
-			expectedCount++
-		}
-		if len(rm.ScopeMetrics[0].Metrics) != expectedCount {
-			return false
-		}
-		for _, m := range rm.ScopeMetrics[0].Metrics {
-			data, ok := m.Data.(metricdata.Histogram[float64])
-			if !ok || len(data.DataPoints) != 5 {
-				return false
-			}
-		}
-		return true
-	}, 1*time.Second, 10*time.Millisecond)
+	rm := metricdata.ResourceMetrics{}
+	err := reader.Collect(t.Context(), &rm)
+	assert.NoError(t, err)
+	require.Len(t, rm.ScopeMetrics, 1)
 
 	host, p, err := net.SplitHostPort(addr)
 	require.NoError(t, err)
@@ -409,16 +383,7 @@ func checkServerMetrics(t *testing.T, reader metric.Reader, stabilityOptIn strin
 		if isNew {
 			expectedCount++
 		}
-		if len(rm.ScopeMetrics[0].Metrics) != expectedCount {
-			return false
-		}
-		for _, m := range rm.ScopeMetrics[0].Metrics {
-			data, ok := m.Data.(metricdata.Histogram[float64])
-			if !ok || len(data.DataPoints) != 5 {
-				return false
-			}
-		}
-		return true
+		return len(rm.ScopeMetrics[0].Metrics) == expectedCount
 	}, 1*time.Second, 10*time.Millisecond)
 
 	require.Len(t, rm.ScopeMetrics, 1)

--- a/instrumentation/google.golang.org/grpc/otelgrpc/grpc_stats_handler_test.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/grpc_stats_handler_test.go
@@ -262,10 +262,36 @@ func checkServerSpans(t *testing.T, sr *tracetest.SpanRecorder, addr string) {
 }
 
 func checkClientMetrics(t *testing.T, reader metric.Reader, addr, stabilityOptIn string) {
-	rm := metricdata.ResourceMetrics{}
-	err := reader.Collect(t.Context(), &rm)
-	assert.NoError(t, err)
-	require.Len(t, rm.ScopeMetrics, 1)
+	var rm metricdata.ResourceMetrics
+	require.Eventually(t, func() bool {
+		rm = metricdata.ResourceMetrics{}
+		if err := reader.Collect(t.Context(), &rm); err != nil {
+			return false
+		}
+		if len(rm.ScopeMetrics) == 0 || len(rm.ScopeMetrics[0].Metrics) == 0 {
+			return false
+		}
+		isOld := stabilityOptIn == "rpc/old" || stabilityOptIn == "rpc/dup"
+		isNew := stabilityOptIn == "" || stabilityOptIn == "rpc/dup"
+
+		var expectedCount int
+		if isOld {
+			expectedCount++
+		}
+		if isNew {
+			expectedCount++
+		}
+		if len(rm.ScopeMetrics[0].Metrics) != expectedCount {
+			return false
+		}
+		for _, m := range rm.ScopeMetrics[0].Metrics {
+			data, ok := m.Data.(metricdata.Histogram[float64])
+			if !ok || len(data.DataPoints) != 5 {
+				return false
+			}
+		}
+		return true
+	}, 1*time.Second, 10*time.Millisecond)
 
 	host, p, err := net.SplitHostPort(addr)
 	require.NoError(t, err)
@@ -383,7 +409,16 @@ func checkServerMetrics(t *testing.T, reader metric.Reader, stabilityOptIn strin
 		if isNew {
 			expectedCount++
 		}
-		return len(rm.ScopeMetrics[0].Metrics) == expectedCount
+		if len(rm.ScopeMetrics[0].Metrics) != expectedCount {
+			return false
+		}
+		for _, m := range rm.ScopeMetrics[0].Metrics {
+			data, ok := m.Data.(metricdata.Histogram[float64])
+			if !ok || len(data.DataPoints) != 5 {
+				return false
+			}
+		}
+		return true
 	}, 1*time.Second, 10*time.Millisecond)
 
 	require.Len(t, rm.ScopeMetrics, 1)

--- a/samplers/jaegerremote/sampler_remote_test.go
+++ b/samplers/jaegerremote/sampler_remote_test.go
@@ -301,14 +301,11 @@ func TestRemotelyControlledSampler_ImmediatelyUpdateOnStartup(t *testing.T) {
 		WithSamplingStrategyFetcher(fetcher),
 		withSamplingStrategyParser(parser),
 	)
-	defer sampler.Close()
-
-	assert.Eventually(t, func() bool {
-		sampler.RLock()
-		defer sampler.RUnlock()
-		s, ok := sampler.sampler.(*rateLimitingSampler)
-		return ok && s.maxTracesPerSecond == 100
-	}, 1*time.Second, 10*time.Millisecond)
+	time.Sleep(100 * time.Millisecond) // waiting for s.pollController
+	sampler.Close()                    // stop pollController, avoid date race
+	s, ok := sampler.sampler.(*rateLimitingSampler)
+	assert.True(t, ok)
+	assert.Equal(t, float64(100), s.maxTracesPerSecond)
 }
 
 func TestRemotelyControlledSampler_multiStrategyResponse(t *testing.T) {

--- a/samplers/jaegerremote/sampler_remote_test.go
+++ b/samplers/jaegerremote/sampler_remote_test.go
@@ -301,11 +301,14 @@ func TestRemotelyControlledSampler_ImmediatelyUpdateOnStartup(t *testing.T) {
 		WithSamplingStrategyFetcher(fetcher),
 		withSamplingStrategyParser(parser),
 	)
-	time.Sleep(100 * time.Millisecond) // waiting for s.pollController
-	sampler.Close()                    // stop pollController, avoid date race
-	s, ok := sampler.sampler.(*rateLimitingSampler)
-	assert.True(t, ok)
-	assert.Equal(t, float64(100), s.maxTracesPerSecond)
+	defer sampler.Close()
+
+	assert.Eventually(t, func() bool {
+		sampler.RLock()
+		defer sampler.RUnlock()
+		s, ok := sampler.sampler.(*rateLimitingSampler)
+		return ok && s.maxTracesPerSecond == 100
+	}, 5*time.Second, 10*time.Millisecond)
 }
 
 func TestRemotelyControlledSampler_multiStrategyResponse(t *testing.T) {

--- a/samplers/jaegerremote/sampler_remote_test.go
+++ b/samplers/jaegerremote/sampler_remote_test.go
@@ -301,11 +301,14 @@ func TestRemotelyControlledSampler_ImmediatelyUpdateOnStartup(t *testing.T) {
 		WithSamplingStrategyFetcher(fetcher),
 		withSamplingStrategyParser(parser),
 	)
-	time.Sleep(100 * time.Millisecond) // waiting for s.pollController
-	sampler.Close()                    // stop pollController, avoid date race
-	s, ok := sampler.sampler.(*rateLimitingSampler)
-	assert.True(t, ok)
-	assert.Equal(t, float64(100), s.maxTracesPerSecond)
+	defer sampler.Close()
+
+	assert.Eventually(t, func() bool {
+		sampler.RLock()
+		defer sampler.RUnlock()
+		s, ok := sampler.sampler.(*rateLimitingSampler)
+		return ok && s.maxTracesPerSecond == 100
+	}, 1*time.Second, 10*time.Millisecond)
 }
 
 func TestRemotelyControlledSampler_multiStrategyResponse(t *testing.T) {


### PR DESCRIPTION
This change stabilizes the `TestRemotelyControlledSampler_ImmediatelyUpdateOnStartup` test in the `jaegerremote` sampler module. The test previously relied on a fixed `time.Sleep` to wait for a background goroutine to update the sampler state, which is a common source of flakiness. 

The fix involves:
1. Replacing `time.Sleep` with `assert.Eventually` to poll for the expected state.
2. Using `RLock()` and `RUnlock()` within the `assert.Eventually` callback to safely access the sampler's internal state, as it is modified concurrently.
3. Adding a `defer sampler.Close()` to ensure proper cleanup.
4. Adding a corresponding entry in `CHANGELOG.md` under the `## [Unreleased]` section.

The fix was verified by running the test 100 times with the `-race` flag enabled.

---
*PR created automatically by Jules for task [15787090289483005347](https://jules.google.com/task/15787090289483005347) started by @pellared*