### PR TITLE
Fix flaky TestRemotelyControlledSampler in jaegerremote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+- Stabilize `TestRemotelyControlledSampler` in `samplers/jaegerremote` by using `Eventually` and proper synchronization.
+
 ### Added
 
 - Add `error.type` attribute to `http.client.request.duration` for transport failures in `otelhttp`. (#8801)

--- a/samplers/jaegerremote/sampler_remote_test.go
+++ b/samplers/jaegerremote/sampler_remote_test.go
@@ -214,9 +214,21 @@ func TestRemotelyControlledSampler(t *testing.T) {
 	agent.AddSamplingStrategy("client app",
 		getSamplingStrategyResponse(jaeger_api_v2.SamplingStrategyType_PROBABILISTIC, testDefaultSamplingProbability))
 	c <- time.Now() // force update based on timer
+
+	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+		remoteSampler.RLock()
+		defer remoteSampler.RUnlock()
+		s, ok := remoteSampler.sampler.(*probabilisticSampler)
+		if assert.True(collect, ok, "sampler should have been updated to probabilistic") {
+			assert.Equal(collect, testDefaultSamplingProbability, s.samplingRate, "Sampler should have been updated from timer")
+		}
+	}, time.Second, 10*time.Millisecond)
+
 	remoteSampler.Close()
 	<-done
 
+	remoteSampler.RLock()
+	defer remoteSampler.RUnlock()
 	s2, ok := remoteSampler.sampler.(*probabilisticSampler)
 	assert.True(t, ok)
 	assert.Equal(t, testDefaultSamplingProbability, s2.samplingRate, "Sampler should have been updated from timer")


### PR DESCRIPTION
Identified and stabilized the flaky `TestRemotelyControlledSampler` in the `samplers/jaegerremote` package. The flakiness was caused by a race condition where the test might attempt to close the sampler or assert its state before a background update (triggered via a manual ticker signal) had completed.

Changes:
- Updated `TestRemotelyControlledSampler` in `samplers/jaegerremote/sampler_remote_test.go` to use `assert.EventuallyWithT` to wait for asynchronous state transitions.
- Added proper `RLock`/`RUnlock` synchronization around assertions that access the sampler's internal state.
- Ensured the update is verified before calling `remoteSampler.Close()` to avoid racing against the background loop's shutdown.
- Updated `CHANGELOG.md` to reflect the fix.

Verified by running the test 100 times with the `-race` flag and ensured all tests in the module pass.

---
*PR created automatically by Jules for task [9624000168389486963](https://jules.google.com/task/9624000168389486963) started by @pellared*