### PR TITLE
Fix data race in jaegerremote sampler test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Set fields implementing `error` interface from `slog` records as `record.SetErr` instead of plain attributes in `go.opentelemetry.io/contrib/bridges/otelslog`. (#8746)
 - Set emitted errors in `go.opentelemetry.io/contrib/bridges/otellogr` as record errors (`Record.SetErr`) instead of `exception.message` attributes. (#8775)
 - Unknown or empty HTTP methods now report "_OTHER" instead of "GET" across all HTTP instrumentations to align with OpenTelemetry semantic conventions. (#8868)
-- Synchronize `updateSamplerViaUpdaters` with the background polling goroutine in `go.opentelemetry.io/contrib/samplers/jaegerremote` to prevent data races.
+- Synchronize manual update call with the background polling goroutine in `go.opentelemetry.io/contrib/samplers/jaegerremote` test to prevent data races.
 - The default span name formatter in `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp` now conforms to the OpenTelemetry HTTP semantic conventions for server span names. (#8871)
   - The default span name is now `{method} {route}` (e.g. `GET /foo/{id}`) when a route pattern is available, or `{method}` (e.g. `GET`) otherwise.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Set fields implementing `error` interface from `slog` records as `record.SetErr` instead of plain attributes in `go.opentelemetry.io/contrib/bridges/otelslog`. (#8746)
 - Set emitted errors in `go.opentelemetry.io/contrib/bridges/otellogr` as record errors (`Record.SetErr`) instead of `exception.message` attributes. (#8775)
 - Unknown or empty HTTP methods now report "_OTHER" instead of "GET" across all HTTP instrumentations to align with OpenTelemetry semantic conventions. (#8868)
+- Synchronize `updateSamplerViaUpdaters` with the background polling goroutine in `go.opentelemetry.io/contrib/samplers/jaegerremote` to prevent data races.
 - The default span name formatter in `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp` now conforms to the OpenTelemetry HTTP semantic conventions for server span names. (#8871)
   - The default span name is now `{method} {route}` (e.g. `GET /foo/{id}`) when a route pattern is available, or `{method}` (e.g. `GET`) otherwise.
 

--- a/samplers/jaegerremote/sampler_remote_test.go
+++ b/samplers/jaegerremote/sampler_remote_test.go
@@ -511,7 +511,6 @@ func TestRemotelyControlledSampler_updateRateLimitingOrProbabilisticSampler(t *t
 			remoteSampler.Lock()
 			err := remoteSampler.updateSamplerViaUpdaters(testCase.res)
 			remoteSampler.Unlock()
-
 			if testCase.shouldErr {
 				require.Error(t, err)
 				return

--- a/samplers/jaegerremote/sampler_remote_test.go
+++ b/samplers/jaegerremote/sampler_remote_test.go
@@ -507,7 +507,11 @@ func TestRemotelyControlledSampler_updateRateLimitingOrProbabilisticSampler(t *t
 				WithInitialSampler(testCase.initSampler),
 			)
 			defer remoteSampler.Close()
+
+			remoteSampler.Lock()
 			err := remoteSampler.updateSamplerViaUpdaters(testCase.res)
+			remoteSampler.Unlock()
+
 			if testCase.shouldErr {
 				require.Error(t, err)
 				return


### PR DESCRIPTION
This PR fixes a data race in the `jaegerremote` sampler tests. Specifically, `TestRemotelyControlledSampler_updateRateLimitingOrProbabilisticSampler` was calling `updateSamplerViaUpdaters` directly without acquiring the `Sampler`'s mutex. Since the `Sampler` starts a background goroutine upon creation that periodically updates its state under the same lock, this lead to a potential write-write race.

The fix involves wrapping the manual update call in the test with `Lock()` and `Unlock()` calls, ensuring proper synchronization. This change aligns with the recommended practices for the package and has been verified with the `-race` flag.

---
*PR created automatically by Jules for task [8129772883760642515](https://jules.google.com/task/8129772883760642515) started by @pellared*