### PR TITLE
Stabilize TestSpanProcessor in zpages package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix flakiness in `go.opentelemetry.io/contrib/zpages` `TestSpanProcessor` by using loose assertions for sampled spans.
+
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
-- Fix flakiness in `go.opentelemetry.io/contrib/zpages` `TestSpanProcessor` by using loose assertions for sampled spans.
+- Fix flakiness in `go.opentelemetry.io/contrib/zpages` `TestSpanProcessor` by using loose assertions for error spans.
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/zpages/spanprocessor_test.go
+++ b/zpages/spanprocessor_test.go
@@ -67,7 +67,7 @@ func TestSpanProcessor(t *testing.T) {
 	}
 	// Test that no more active spans.
 	assert.Empty(t, zsp.activeSpans(spanName))
-	assert.Len(t, zsp.errorSpans(spanName), 1)
+	assert.GreaterOrEqual(t, len(zsp.errorSpans(spanName)), 1)
 	numLatencySamples := 0
 	for i := range defaultBoundaries.numBuckets() {
 		numLatencySamples += len(zsp.spansByLatency(spanName, i))


### PR DESCRIPTION
I have stabilized the `TestSpanProcessor` in the `zpages` package. 

The test was previously using an exact length assertion (`assert.Len(t, zsp.errorSpans(spanName), 1)`) to verify that an error span was captured. However, the `SpanProcessor` in `zpages` implements a 1-second sampling window per bucket. If the test happens to end spans across a second boundary, it's possible for more than one error span to be recorded, causing the exact length assertion to fail.

I have updated the assertion to use `assert.GreaterOrEqual(t, len(zsp.errorSpans(spanName)), 1)`, which ensures that at least one error span is captured without being sensitive to the sampling window timing. This pattern is already used in other tests in the same file to avoid flakiness.

I have also added a corresponding entry to the `CHANGELOG.md`.

---
*PR created automatically by Jules for task [815348205833293428](https://jules.google.com/task/815348205833293428) started by @pellared*