### PR TITLE
zpages: stabilize TestSpanProcessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Stabilize `TestSpanProcessor` in `go.opentelemetry.io/contrib/zpages` by accounting for the 1-second sampling window.
 - Fix header attributes lost when using sub-spans in `go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace`. (#8797)
 - Validate `encoding` configuration for OTLP HTTP exporters in `go.opentelemetry.io/contrib/otelconf`. (#8772)
 - Remove the custom body wrapper from the request's body after the request is processed to allow body type comparisons with the original type in `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp` and `go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux`. (#6914)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- Stabilize `TestSpanProcessor` in `go.opentelemetry.io/contrib/zpages` by accounting for the 1-second sampling window.
+
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->
 
@@ -30,7 +34,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
-- Stabilize `TestSpanProcessor` in `go.opentelemetry.io/contrib/zpages` by accounting for the 1-second sampling window.
 - Fix header attributes lost when using sub-spans in `go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace`. (#8797)
 - Validate `encoding` configuration for OTLP HTTP exporters in `go.opentelemetry.io/contrib/otelconf`. (#8772)
 - Remove the custom body wrapper from the request's body after the request is processed to allow body type comparisons with the original type in `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp` and `go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux`. (#6914)

--- a/zpages/spanprocessor_test.go
+++ b/zpages/spanprocessor_test.go
@@ -67,7 +67,7 @@ func TestSpanProcessor(t *testing.T) {
 	}
 	// Test that no more active spans.
 	assert.Empty(t, zsp.activeSpans(spanName))
-	assert.Len(t, zsp.errorSpans(spanName), 1)
+	assert.GreaterOrEqual(t, len(zsp.errorSpans(spanName)), 1)
 	numLatencySamples := 0
 	for i := range defaultBoundaries.numBuckets() {
 		numLatencySamples += len(zsp.spansByLatency(spanName, i))


### PR DESCRIPTION
Modified TestSpanProcessor in zpages/spanprocessor_test.go to use assert.GreaterOrEqual for error span counts. This accounts for the 1-second sampling window in the SpanProcessor, which could cause the test to capture multiple spans if execution crosses a second boundary, leading to flaky failures when asserting an exact length of 1.

---
*PR created automatically by Jules for task [18031936164201696144](https://jules.google.com/task/18031936164201696144) started by @pellared*